### PR TITLE
Addition of the 'try except' block to correctly convert the error to json format

### DIFF
--- a/src/Horse.Jhonson.pas
+++ b/src/Horse.Jhonson.pas
@@ -29,7 +29,7 @@ begin
     try
       Next;
     except
-      Exit;
+      raise;
     end;
   finally
 

--- a/src/Horse.Jhonson.pas
+++ b/src/Horse.Jhonson.pas
@@ -26,7 +26,11 @@ begin
   end;
 
   try
-    Next;
+    try
+      Next;
+    except
+      Exit;
+    end;
   finally
 
     LWebResponse := THorseHackResponse(Res).GetWebResponse;


### PR DESCRIPTION
If any exception is thrown, it will now correctly transform the value into json