### PR TITLE
Settings for compilation in Delphi XE6

### DIFF
--- a/src/Horse.Jhonson.pas
+++ b/src/Horse.Jhonson.pas
@@ -40,7 +40,7 @@ begin
 
     if Assigned(LContent) and LContent.InheritsFrom({$IF DEFINED(FPC)}TJsonData{$ELSE}TJSONValue{$ENDIF}) then
     begin
-      LWebResponse.Content := {$IF DEFINED(FPC)}TJsonData(LContent).AsJSON {$ELSE}TJSONValue(LContent).ToJSON{$ENDIF};
+      LWebResponse.Content := {$IF DEFINED(FPC)}TJsonData(LContent).AsJSON {$ELSE}{$IF CompilerVersion > 27.0}TJSONValue(LContent).ToJSON{$ELSE}TJSONValue(LContent).ToString{$ENDIF}{$ENDIF};
       LWebResponse.ContentType := 'application/json';
     end;
   end;


### PR DESCRIPTION
I made some adjustments to allow the compilation and use of jhonson in Delphi XE6.

As in the XE6 version Delphi does not have TJSONValue (). ToJSON, I used a build directive to check if the build version is larger than XE6, to use TJSONValue () instead. ToString, which works in the XE6 version.

I performed tests on Delphi XE6 and 10.3.3 Rio