### PR TITLE
Correção de vazamento de memória do objeto body sendo instanciado dua…

### DIFF
--- a/src/Horse.Jhonson.pas
+++ b/src/Horse.Jhonson.pas
@@ -54,6 +54,11 @@ begin
       raise EHorseCallbackInterrupted.Create;
     end;
 
+    {$IF DEFINED(FPC)}
+    if Assigned(Req.Body<TObject>) then
+      Req.Body<TObject>.Free;
+    {$ENDIF}
+
     Req.Body(LJSON);
   end;
 


### PR DESCRIPTION
…s vezes no Lazarus

Ele chama a função execute internal duas vezes o que chama o set middle duas vezes antes de dar o free, atribuindo o Body duas vezes e assim ficando um objeto body sem liberar a memória com o Free no middleare que libera o Body.

![image](https://github.com/user-attachments/assets/0018d4d9-e2f1-462b-bc96-a7e524352bb2)
![image](https://github.com/user-attachments/assets/6be3f378-3b32-4a5a-8ff5-ad65264f8feb)
![image](https://github.com/user-attachments/assets/55cebc4e-bfff-4ae1-92eb-b697bc9b52cd)
![image](https://github.com/user-attachments/assets/349257e7-6ac8-4a03-a0a3-ebd6cbc322e9)
![image](https://github.com/user-attachments/assets/23d47d71-8718-4f16-b43f-6afc1099854a)
