### PR TITLE
Feature for don't encode above ASCII 127 if JSON is in UTF-8

### DIFF
--- a/src/Horse.Jhonson.pas
+++ b/src/Horse.Jhonson.pas
@@ -38,6 +38,9 @@ end;
 procedure Middleware(Req: THorseRequest; Res: THorseResponse; Next: {$IF DEFINED(FPC)}TNextProc{$ELSE}TProc{$ENDIF});
 var
   LJSON: {$IF DEFINED(FPC)}TJsonData{$ELSE}TJSONValue{$ENDIF};
+  {$IF CompilerVersion >= 36}
+  ops: TJSONValue.TJsonOutputOptions;
+  {$ENDIF}
 begin
   if (Req.MethodType in [mtPost, mtPut, mtPatch]) and (Pos('application/json', Req.RawWebRequest.ContentType) > 0) then
   begin

--- a/src/Horse.Jhonson.pas
+++ b/src/Horse.Jhonson.pas
@@ -70,7 +70,16 @@ begin
       {$IF DEFINED(FPC)}
       Res.RawWebResponse.ContentStream := TStringStream.Create(TJsonData(Res.Content).AsJSON);
       {$ELSE}
-      Res.RawWebResponse.Content := TJSONValue(Res.Content).ToJSON;
+    		{$IF CompilerVersion >= 36}
+    		  if SameText(Charset, 'utf-8') then
+    			  ops := [TJSONValue.TJSONOutputOption.EncodeBelow32]
+    		  else
+    			  ops := [TJSONValue.TJSONOutputOption.EncodeBelow32, TJSONValue.TJSONOutputOption.EncodeAbove127];
+    
+    		  Res.RawWebResponse.Content := TJSONValue(Res.Content).ToJSON(ops);
+    		{$ELSE}
+    		  Res.RawWebResponse.Content := TJSONValue(Res.Content).ToJSON;
+    		{$ENDIF}
       {$ENDIF}
       Res.RawWebResponse.ContentType := 'application/json; charset=' + Charset;
     end;


### PR DESCRIPTION
For UTF-8 JSON files don't encode chars above ASCII 127 (#20)