### PR TITLE
fix: resolve FPC 3.2.2 compilation issue with recent Horse core (clos…

### DIFF
--- a/src/Horse.Jhonson.pas
+++ b/src/Horse.Jhonson.pas
@@ -214,7 +214,7 @@ begin
       Result := JhonsonFPCModern(ACharset, AErrorCallback);
     {$ELSE}
       GCharset := ACharset;
-      Result := MiddlewareFPCLegacy;
+      Result := THorseCallback(@MiddlewareFPCLegacy);
     {$ENDIF}
   {$ELSE}
     Result := JhonsonDelphi(ACharset, AErrorCallback);


### PR DESCRIPTION
# Correção 

Este Pull Request resolve um erro de compilação no `Horse.Jhonson` ao utilizar o **FPC 3.2.2 / Lazarus** (sem referências de função) contra versões recentes do **Horse core** (onde o `THorseCallback` foi redefinido como um `Pointer` no FPC).

No FPC, atribuir um procedimento diretamente a uma variável do tipo `Pointer` sem o operador de endereço `@` resulta no erro de tipos incompatíveis:
`got "MiddlewareFPCLegacy(THorseRequest;THorseResponse;TNextProc);" expected "Pointer"`

## Alterações

- Adicionado o operador de endereço `@` e o typecast explícito para `THorseCallback` no bloco de mapeamento do FPC legado dentro de `src/Horse.Jhonson.pas`.

```pascal
    {$IF DEFINED(HORSE_FPC_FUNCTIONREFERENCES)}
      Result := JhonsonFPCModern(ACharset, AErrorCallback);
    {$ELSE}
      GCharset := ACharset;
      Result := THorseCallback(@MiddlewareFPCLegacy); // <-- Corrigido aqui
    {$ENDIF}
