### PR TITLE
Fix: Resolve FPC generic compilation bug by exposing helper functions…

### DIFF
--- a/src/Horse.Jhonson.pas
+++ b/src/Horse.Jhonson.pas
@@ -30,6 +30,11 @@ function Jhonson: THorseCallback; overload;
 function Jhonson(const ACharset: string): THorseCallback; overload;
 function Jhonson(const ACharset: string; const AErrorCallback: TJhonsonErrorCallback): THorseCallback; overload;
 
+{$IFDEF FPC}
+procedure JsonToClassFPC(const AJSONStr: string; AObject: TObject);
+function ClassToJsonFPC(AObject: TObject): string;
+{$ENDIF}
+
 implementation
 
 {$IFDEF FPC}


### PR DESCRIPTION
Fix: Resolve FPC generic compilation bug by exposing helpers in interface
Descrição do Problema
Ao tentar compilar o middleware Jhonson em projetos utilizando o Lazarus / Free Pascal Compiler (FPC) (validado na versão 3.2.2), ocorria o seguinte erro de compilação:

Horse.Jhonson.pas(168,4) Error: Global Generic template references static symtable

Causa: O método genérico THorseRequestHelper.BodyAs<T> (definido na seção interface) faz chamadas internas para a procedure JsonToClassFPC e a função ClassToJsonFPC. No FPC, a resolução de escopo em templates genéricos globais impede a referência de símbolos estáticos/locais declarados unicamente no bloco de implementation.

O que este PR faz?
Declara os protótipos de assinatura de JsonToClassFPC e ClassToJsonFPC na seção interface de Horse.Jhonson.pas sob a diretiva condicional {$IFDEF FPC}.
Garante a visibilidade requerida pelo Free Pascal Compiler para a correta instanciação tardia do template genérico de classe do helper.
Preserva 100% da compatibilidade de sintaxe e comportamento em todas as versões do Delphi.
Testes Realizados
O middleware foi testado e compilado com sucesso nas seguintes plataformas/compiladores após a correção:

Delphi: 10 Seattle, 11 Alexandria, 12 Athens, 13
FPC / Lazarus: v3.2.2 (Win32 & Linux 64-bit via dcclinux64)